### PR TITLE
[Chore] Update link for PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/git-template/issues/??
+https://github.com/nimblehq/nimble-ecommerce-ios/issues/??
 
 ## What happened 👀
 


### PR DESCRIPTION
https://github.com/nimblehq/git-template/issues/??

## What happened 👀

- Change from `https://github.com/nimblehq/git-template/issues/??` to `https://github.com/nimblehq/nimble-ecommerce-ios/issues/??`