### PR TITLE
[50] [UI] As a user, I can see the product size selection section on the Product Detail screen

### DIFF
--- a/ecommerce-ios.xcodeproj/project.pbxproj
+++ b/ecommerce-ios.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		229D54EC2654C8AB00114B3E /* NoItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54EB2654C8AB00114B3E /* NoItemView.swift */; };
 		229D54F02654D53700114B3E /* ProductInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54EF2654D53700114B3E /* ProductInformationView.swift */; };
 		229D54F22654D54100114B3E /* ProductInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54F12654D54100114B3E /* ProductInformationViewModel.swift */; };
+		229D54F52654EA1E00114B3E /* SizeCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54F42654EA1E00114B3E /* SizeCellViewModel.swift */; };
+		229D54F72654EA2800114B3E /* SizeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54F62654EA2800114B3E /* SizeCell.swift */; };
+		229D54FA2654F86600114B3E /* SizeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54F92654F86600114B3E /* SizeSelectionView.swift */; };
+		229D54FC2654F87000114B3E /* SizeSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D54FB2654F87000114B3E /* SizeSelectionViewModel.swift */; };
 		6467343FA56259DB3EDB535D /* Pods_ecommerce_iosTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D984921251D777A83D13F4C /* Pods_ecommerce_iosTests.framework */; };
 		68875C670E9C0BAA948075CD /* Pods_ecommerce_ios_ecommerce_iosUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBE0FAF7BF83FE643955750F /* Pods_ecommerce_ios_ecommerce_iosUITests.framework */; };
 		9024843A264D2320008ECEE5 /* View+TabbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90248439264D2320008ECEE5 /* View+TabbarItem.swift */; };
@@ -146,6 +150,10 @@
 		229D54EB2654C8AB00114B3E /* NoItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoItemView.swift; sourceTree = "<group>"; };
 		229D54EF2654D53700114B3E /* ProductInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInformationView.swift; sourceTree = "<group>"; };
 		229D54F12654D54100114B3E /* ProductInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInformationViewModel.swift; sourceTree = "<group>"; };
+		229D54F42654EA1E00114B3E /* SizeCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeCellViewModel.swift; sourceTree = "<group>"; };
+		229D54F62654EA2800114B3E /* SizeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeCell.swift; sourceTree = "<group>"; };
+		229D54F92654F86600114B3E /* SizeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeSelectionView.swift; sourceTree = "<group>"; };
+		229D54FB2654F87000114B3E /* SizeSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeSelectionViewModel.swift; sourceTree = "<group>"; };
 		281BE23A4441B9EDB3717DCA /* Pods-ecommerce-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ecommerce-ios.release.xcconfig"; path = "Target Support Files/Pods-ecommerce-ios/Pods-ecommerce-ios.release.xcconfig"; sourceTree = "<group>"; };
 		3D984921251D777A83D13F4C /* Pods_ecommerce_iosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ecommerce_iosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D8676CF800C031A87683C6E /* Pods_ecommerce_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ecommerce_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -355,6 +363,24 @@
 			path = ProductInformation;
 			sourceTree = "<group>";
 		};
+		229D54F32654EA0100114B3E /* SizeCell */ = {
+			isa = PBXGroup;
+			children = (
+				229D54F62654EA2800114B3E /* SizeCell.swift */,
+				229D54F42654EA1E00114B3E /* SizeCellViewModel.swift */,
+			);
+			path = SizeCell;
+			sourceTree = "<group>";
+		};
+		229D54F82654F85600114B3E /* SizeSelection */ = {
+			isa = PBXGroup;
+			children = (
+				229D54F92654F86600114B3E /* SizeSelectionView.swift */,
+				229D54FB2654F87000114B3E /* SizeSelectionViewModel.swift */,
+			);
+			path = SizeSelection;
+			sourceTree = "<group>";
+		};
 		22E67F73265248B900302C38 /* View+NavigationBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -456,6 +482,8 @@
 				229D54EE2654D52100114B3E /* ProductInformation */,
 				222EB87C26525D0F00BF46BD /* SearchBar */,
 				2282E9D82652347100340FEE /* SearchItemCell */,
+				229D54F32654EA0100114B3E /* SizeCell */,
+				229D54F82654F85600114B3E /* SizeSelection */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -930,6 +958,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				90D09626264938DE00717D05 /* TabbarView.swift in Sources */,
+				229D54FA2654F86600114B3E /* SizeSelectionView.swift in Sources */,
 				90248442264E63E6008ECEE5 /* SuggestedView.swift in Sources */,
 				222EB8BB265280FC00BF46BD /* Double+NumberFormatter.swift in Sources */,
 				90D0962926493A5100717D05 /* HomeScreen.swift in Sources */,
@@ -945,6 +974,7 @@
 				90248452265270ED008ECEE5 /* CategoryView.swift in Sources */,
 				902935822653C2E400C804BF /* R.typealiases.swift in Sources */,
 				222EB8B02652802700BF46BD /* NumberFormatters+Formatter.swift in Sources */,
+				229D54F72654EA2800114B3E /* SizeCell.swift in Sources */,
 				2282E9DF2652347100340FEE /* SearchItemCellViewModel.swift in Sources */,
 				229D54EC2654C8AB00114B3E /* NoItemView.swift in Sources */,
 				90D0962E26493AA400717D05 /* SearchScreen.swift in Sources */,
@@ -959,6 +989,7 @@
 				222EB886265268BA00BF46BD /* View+CustomOverlayView.swift in Sources */,
 				222EB8AB26527EC600BF46BD /* ProductCell.swift in Sources */,
 				224CB00E264C53A40084B50B /* Array+Safe.swift in Sources */,
+				229D54F52654EA1E00114B3E /* SizeCellViewModel.swift in Sources */,
 				222EB88E2652723B00BF46BD /* String+Utility.swift in Sources */,
 				9029357E2653C03900C804BF /* ContentView.swift in Sources */,
 				224CB006264C3F7A0084B50B /* ScreenSize+Ultility.swift in Sources */,
@@ -969,6 +1000,7 @@
 				229D54E52653D0F500114B3E /* SearchResultScreenViewModel.swift in Sources */,
 				9024843A264D2320008ECEE5 /* View+TabbarItem.swift in Sources */,
 				909562A32643EC950028E442 /* R.generated.swift in Sources */,
+				229D54FC2654F87000114B3E /* SizeSelectionViewModel.swift in Sources */,
 				2282E9C72652320500340FEE /* View+CustomNavigationBarLargeTitle.swift in Sources */,
 				902935802653C13000C804BF /* View+Hidden.swift in Sources */,
 				2282E9BE265230FF00340FEE /* CustomNavigationBarContentView.swift in Sources */,

--- a/ecommerce-ios/Extensions/Color+Application.swift
+++ b/ecommerce-ios/Extensions/Color+Application.swift
@@ -47,6 +47,9 @@ extension Color {
     /// #000000 Black with alpha 0.2
     static var blackAlpha2: Color { Color(hex: 0x000000, alpha: 0.2) }
 
+    /// #000000 Black with alpha 0.12
+    static var blackAlpha12: Color { Color(hex: 0x000000, alpha: 0.12) }
+
     // MARK: - Initialize
 
     init(hex: UInt, alpha: Double = 1.0) {

--- a/ecommerce-ios/Views/SizeCell/SizeCell.swift
+++ b/ecommerce-ios/Views/SizeCell/SizeCell.swift
@@ -1,0 +1,35 @@
+//
+//  SizeCell.swift
+//  ecommerce-ios
+//
+//  Created by Nguyen M. Tam on 19/05/2021.
+//
+
+import SwiftUI
+
+struct SizeCell: View {
+
+    let viewModel: SizeCellViewModel
+
+    var body: some View {
+        Color.clear
+            .overlay(text)
+    }
+
+    private var text: some View {
+        Text(viewModel.name)
+            .textCase(.uppercase)
+    }
+
+    init(viewModel: SizeCellViewModel) {
+        self.viewModel = viewModel
+    }
+}
+
+struct SizeCell_Preview: PreviewProvider {
+
+    static var previews: some View {
+        SizeCell(viewModel: .init(id: "s", name: "s"))
+            .frame(width: 100.0, height: 100.0)
+    }
+}

--- a/ecommerce-ios/Views/SizeCell/SizeCellViewModel.swift
+++ b/ecommerce-ios/Views/SizeCell/SizeCellViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  SizeCellViewModel.swift
+//  ecommerce-ios
+//
+//  Created by Nguyen M. Tam on 19/05/2021.
+//
+
+struct SizeCellViewModel: Identifiable, Hashable {
+
+    let id: String
+    let name: String
+}

--- a/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
+++ b/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
@@ -1,0 +1,82 @@
+//
+//  SizeSelectionView.swift
+//  ecommerce-ios
+//
+//  Created by Nguyen M. Tam on 19/05/2021.
+//
+
+import SwiftUI
+
+struct SizeSelectionView: View {
+
+    @State private var selectedViewModel: SizeCellViewModel
+
+    let cellViewModels: [SizeCellViewModel]
+
+    private let spacing: CGFloat = 8.0
+    private let horizontalSpacing: CGFloat = 34.0
+
+    private var itemWidth: CGFloat {
+        let numberOfColumns = CGFloat(self.cellViewModels.count)
+        return ((screenWidth - spacing * (numberOfColumns + 1) - horizontalSpacing) / numberOfColumns).rounded(.down)
+    }
+
+    private var columns: [GridItem] {
+        [.init(.adaptive(minimum: itemWidth))]
+    }
+
+    private var grayGoundRectangle: some View {
+        RoundedRectangle(cornerRadius: 8.0)
+            .stroke(Color.blackAlpha12, lineWidth: 1.0)
+    }
+
+    private var blueRoundRectangle: some View {
+        RoundedRectangle(cornerRadius: 8.0)
+            .stroke(Color.mainBlue, lineWidth: 1.0)
+    }
+
+    var body: some View {
+        VStack {
+            LazyVGrid(columns: columns, spacing: spacing) {
+                ForEach(cellViewModels) { cellViewModel in
+                    ZStack {
+                        if selectedViewModel == cellViewModel {
+                            SizeCell(viewModel: cellViewModel)
+                                .frame(width: itemWidth, height: 80.0)
+                                .background(blueRoundRectangle)
+                                .onTapGesture {
+                                    selectedViewModel = cellViewModel
+                                }
+                        } else {
+                            SizeCell(viewModel: cellViewModel)
+                                .frame(width: itemWidth, height: 80.0)
+                                .background(grayGoundRectangle)
+                                .onTapGesture {
+                                    selectedViewModel = cellViewModel
+                                }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    init(cellViewModels: [SizeCellViewModel]) {
+        self.cellViewModels = cellViewModels
+        selectedViewModel = cellViewModels.first!
+    }
+}
+
+struct SizeSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        SizeSelectionView(cellViewModels: [
+            SizeCellViewModel(id: "s", name: "s"),
+            SizeCellViewModel(id: "m", name: "m"),
+            SizeCellViewModel(id: "l", name: "l"),
+            SizeCellViewModel(id: "xl", name: "xxl"),
+            SizeCellViewModel(id: "xxl", name: "xxl"),
+            SizeCellViewModel(id: "xxxl", name: "xxxl")
+        ])
+        .padding(.horizontal, 17.0)
+    }
+}

--- a/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
+++ b/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SizeSelectionView: View {
 
-    @State private var selectedViewModel: SizeCellViewModel
+    @State private var selectedViewModel: SizeCellViewModel?
 
     let cellViewModels: [SizeCellViewModel]
 
@@ -58,7 +58,7 @@ struct SizeSelectionView: View {
 
     init(cellViewModels: [SizeCellViewModel]) {
         self.cellViewModels = cellViewModels
-        selectedViewModel = cellViewModels.first!
+        selectedViewModel = cellViewModels.first
     }
 }
 

--- a/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
+++ b/ecommerce-ios/Views/SizeSelection/SizeSelectionView.swift
@@ -16,13 +16,8 @@ struct SizeSelectionView: View {
     private let spacing: CGFloat = 8.0
     private let horizontalSpacing: CGFloat = 34.0
 
-    private var itemWidth: CGFloat {
-        let numberOfColumns = CGFloat(self.cellViewModels.count)
-        return ((screenWidth - spacing * (numberOfColumns + 1) - horizontalSpacing) / numberOfColumns).rounded(.down)
-    }
-
     private var columns: [GridItem] {
-        [.init(.adaptive(minimum: itemWidth))]
+        .init(repeating: GridItem(.flexible()), count: self.cellViewModels.count)
     }
 
     private var grayGoundRectangle: some View {
@@ -42,14 +37,14 @@ struct SizeSelectionView: View {
                     ZStack {
                         if selectedViewModel == cellViewModel {
                             SizeCell(viewModel: cellViewModel)
-                                .frame(width: itemWidth, height: 80.0)
+                                .frame(height: 80.0)
                                 .background(blueRoundRectangle)
                                 .onTapGesture {
                                     selectedViewModel = cellViewModel
                                 }
                         } else {
                             SizeCell(viewModel: cellViewModel)
-                                .frame(width: itemWidth, height: 80.0)
+                                .frame(height: 80.0)
                                 .background(grayGoundRectangle)
                                 .onTapGesture {
                                     selectedViewModel = cellViewModel
@@ -73,7 +68,7 @@ struct SizeSelectionView_Previews: PreviewProvider {
             SizeCellViewModel(id: "s", name: "s"),
             SizeCellViewModel(id: "m", name: "m"),
             SizeCellViewModel(id: "l", name: "l"),
-            SizeCellViewModel(id: "xl", name: "xxl"),
+            SizeCellViewModel(id: "xl", name: "xl"),
             SizeCellViewModel(id: "xxl", name: "xxl"),
             SizeCellViewModel(id: "xxxl", name: "xxxl")
         ])

--- a/ecommerce-ios/Views/SizeSelection/SizeSelectionViewModel.swift
+++ b/ecommerce-ios/Views/SizeSelection/SizeSelectionViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  SizeSelectionViewModel.swift
+//  ecommerce-ios
+//
+//  Created by Nguyen M. Tam on 19/05/2021.
+//
+
+struct SizeSelectionViewModel {
+
+    let sizes: [SizeCellViewModel]
+}


### PR DESCRIPTION
https://github.com/nimblehq/nimble-ecommerce-ios/issues/50

## What happened 👀

As a user, I can see the product size selection section on the Product Detail screen.

The product size selection section on the Product Detail screen contains:

- "Size" title label on the top
- A size collection, each item contains:
- A label showing the size name
  - Gray border for the item in the normal state
  - Blue border for the item in the selected state
- User can select the size

## Insight 📝

- Create `SizeCell` to perform a selection for size 
- Create `SizeSelectionView` to perform a collection of size, all sizes are horizontally stack on 1 row
- Implement the selecting action for `SizeSelectionView`
 
## Proof Of Work 📹

A SizeSelectionView:

![2021-05-19 21 23 51](https://user-images.githubusercontent.com/23162627/118830793-6bc69800-b8e9-11eb-9d67-ac4a6d052ebb.gif)
