### PR TITLE
[42] [Integration] As a user, I only see Widget in Light theme

### DIFF
--- a/ecommerce-iosWidget/EcommerceiOSWidget.swift
+++ b/ecommerce-iosWidget/EcommerceiOSWidget.swift
@@ -41,6 +41,8 @@ struct EcommerceiOSWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: ProductListProvider()) { entry in
             EcommerceiOSWidgetEntryView(entry: entry)
+                .environment(\.colorScheme, .light)
+                .background(Color.white)
         }
         .configurationDisplayName("My Widget")
         .description("This is an example widget.")


### PR DESCRIPTION
resolves https://github.com/nimblehq/nimble-ecommerce-ios/issues/42

## What happened 👀

Override theme with light theme
 
## Insight 📝

We don't have dark theme design so we override theme with light and add background color.
 
## Proof Of Work 📹

<img width=300 src="https://user-images.githubusercontent.com/6356137/119439504-af3b5f00-bd4c-11eb-95c9-bd3b44608647.png">
