### PR TITLE
[64] [63] [66] [Integrate] As a user, I can go to Product Collection

### DIFF
--- a/ecommerce-ios.xcodeproj/project.pbxproj
+++ b/ecommerce-ios.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		229D551B26565FC600114B3E /* SettingsSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229D551A26565FC600114B3E /* SettingsSectionViewModel.swift */; };
 		6467343FA56259DB3EDB535D /* Pods_ecommerce_iosTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D984921251D777A83D13F4C /* Pods_ecommerce_iosTests.framework */; };
 		68875C670E9C0BAA948075CD /* Pods_ecommerce_ios_ecommerce_iosUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBE0FAF7BF83FE643955750F /* Pods_ecommerce_ios_ecommerce_iosUITests.framework */; };
+		9023F611265E2FA100629573 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9023F610265E2FA100629573 /* HomeViewModel.swift */; };
+		9023F613265E359600629573 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90248444264E6424008ECEE5 /* Product.swift */; };
+		9023F616265E3AED00629573 /* CollectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9023F615265E3AED00629573 /* CollectionScreen.swift */; };
+		9023F618265E3B2D00629573 /* CollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9023F617265E3B2D00629573 /* CollectionViewModel.swift */; };
 		9024843A264D2320008ECEE5 /* View+TabbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90248439264D2320008ECEE5 /* View+TabbarItem.swift */; };
 		9024843D264D2527008ECEE5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9024843C264D2527008ECEE5 /* Constants.swift */; };
 		90248442264E63E6008ECEE5 /* SuggestedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90248441264E63E6008ECEE5 /* SuggestedView.swift */; };
@@ -239,6 +243,9 @@
 		4D8676CF800C031A87683C6E /* Pods_ecommerce_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ecommerce_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		527EEA037DD196936C693420 /* Pods-ecommerce-ios-ecommerce-iosUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ecommerce-ios-ecommerce-iosUITests.debug.xcconfig"; path = "Target Support Files/Pods-ecommerce-ios-ecommerce-iosUITests/Pods-ecommerce-ios-ecommerce-iosUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		5E6F06D5536065202D17B037 /* Pods-ecommerce-iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ecommerce-iosTests.debug.xcconfig"; path = "Target Support Files/Pods-ecommerce-iosTests/Pods-ecommerce-iosTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9023F610265E2FA100629573 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		9023F615265E3AED00629573 /* CollectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionScreen.swift; sourceTree = "<group>"; };
+		9023F617265E3B2D00629573 /* CollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewModel.swift; sourceTree = "<group>"; };
 		90248439264D2320008ECEE5 /* View+TabbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+TabbarItem.swift"; sourceTree = "<group>"; };
 		9024843C264D2527008ECEE5 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		90248441264E63E6008ECEE5 /* SuggestedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedView.swift; sourceTree = "<group>"; };
@@ -635,6 +642,15 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		9023F614265E3AAA00629573 /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				9023F615265E3AED00629573 /* CollectionScreen.swift */,
+				9023F617265E3B2D00629573 /* CollectionViewModel.swift */,
+			);
+			path = Collection;
+			sourceTree = "<group>";
+		};
 		9024843B264D2515008ECEE5 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
@@ -752,6 +768,7 @@
 			children = (
 				9024844A26522DF6008ECEE5 /* View */,
 				90D0962826493A5100717D05 /* HomeScreen.swift */,
+				9023F610265E2FA100629573 /* HomeViewModel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -805,6 +822,7 @@
 		90D907202643DD9400D37F16 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				9023F614265E3AAA00629573 /* Collection */,
 				227E046C2657885400B23543 /* Filter */,
 				90D09627264939D900717D05 /* Home */,
 				90D907302643DE4800D37F16 /* Main */,
@@ -1201,6 +1219,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9023F613265E359600629573 /* Product.swift in Sources */,
 				090763582657558800E9D946 /* LargeWidgetTitleView.swift in Sources */,
 				09A702F8265254B500B8BDE6 /* EcommerceiOSWidget.swift in Sources */,
 				09A7030E265371FC00B8BDE6 /* ItemsGridView.swift in Sources */,
@@ -1250,6 +1269,7 @@
 				90248454265271E1008ECEE5 /* CategoryCollectionView.swift in Sources */,
 				229D54EA2654C8A000114B3E /* NoItemViewModel.swift in Sources */,
 				90248452265270ED008ECEE5 /* CategoryView.swift in Sources */,
+				9023F611265E2FA100629573 /* HomeViewModel.swift in Sources */,
 				227E046E2657886600B23543 /* FilterScreen.swift in Sources */,
 				229D55042655598500114B3E /* ColorCell.swift in Sources */,
 				902935822653C2E400C804BF /* R.typealiases.swift in Sources */,
@@ -1261,6 +1281,7 @@
 				90D0962E26493AA400717D05 /* SearchScreen.swift in Sources */,
 				9024843D264D2527008ECEE5 /* Constants.swift in Sources */,
 				227E047A2657B55000B23543 /* ProductSizeType.swift in Sources */,
+				9023F618265E3B2D00629573 /* CollectionViewModel.swift in Sources */,
 				90248445264E6424008ECEE5 /* Product.swift in Sources */,
 				229D551B26565FC600114B3E /* SettingsSectionViewModel.swift in Sources */,
 				229D54E72653D34600114B3E /* SearchResultItem.swift in Sources */,
@@ -1281,6 +1302,7 @@
 				224CB00E264C53A40084B50B /* Array+Safe.swift in Sources */,
 				229D54F52654EA1E00114B3E /* SizeCellViewModel.swift in Sources */,
 				222EB88E2652723B00BF46BD /* String+Utility.swift in Sources */,
+				9023F616265E3AED00629573 /* CollectionScreen.swift in Sources */,
 				227E046426577A1A00B23543 /* SortType.swift in Sources */,
 				9029357E2653C03900C804BF /* ContentView.swift in Sources */,
 				224CB006264C3F7A0084B50B /* ScreenSize+Ultility.swift in Sources */,

--- a/ecommerce-ios/Models/Price.swift
+++ b/ecommerce-ios/Models/Price.swift
@@ -10,6 +10,10 @@ import Foundation
 struct Price: Identifiable {
 
     let id: String
-    let amount: Int
+    let amount: Double
     let currency: String
+
+    var formattedPrice: String {
+        "\(currency)\(amount.formatted(with: .currencyWithNoDecimalDigit))"
+    }
 }

--- a/ecommerce-ios/Models/Product.swift
+++ b/ecommerce-ios/Models/Product.swift
@@ -13,4 +13,57 @@ struct Product: Identifiable {
     let name: String
     let imageName: String
     let price: Price
+
+    var formattedPrice: String { price.formattedPrice }
+}
+
+// MARK: - Product dummy
+
+extension Product {
+
+    private enum CubeType: String, CaseIterable {
+
+        case gray, pink, indigo, honey, gray1, pink1, indigo1, honey1
+
+        var value: String {
+            switch self {
+            case .gray, .gray1: return "gray"
+            case .pink, .pink1: return "pink"
+            case .indigo, .indigo1: return "indigo"
+            case .honey, .honey1: return "honey"
+            }
+        }
+
+        var name: String {
+            "\(value) cube"
+        }
+
+        var imageName: String {
+            "dummy-tshirt/tshirt-cube-\(value)"
+        }
+    }
+
+    static var suggestedProduct: Product {
+        Product(
+            id: "suggested_product",
+            name: "Poly Cube 2021",
+            imageName: "",
+            price: Price(id: "price1", amount: 8_000, currency: "฿")
+        )
+    }
+
+    static var products: [Product] {
+        var items: [Product] = []
+        for (index, item) in CubeType.allCases.enumerated() {
+            items.append(
+                Product(
+                    id: "\(index)",
+                    name: item.name,
+                    imageName: item.imageName,
+                    price: Price(id: "\(index)", amount: Double(index) * 1_000.0, currency: "฿")
+                )
+            )
+        }
+        return items
+    }
 }

--- a/ecommerce-ios/Models/SearchResultItem.swift
+++ b/ecommerce-ios/Models/SearchResultItem.swift
@@ -17,38 +17,16 @@ extension SearchResultItem {
 
     static var searchResultItems: [SearchResultItem] {
         var items: [SearchResultItem] = []
-        for (index, cubeType) in CubeType.allCases.enumerated() {
+        for (index, item) in Product.products.enumerated() {
             items.append(
                 SearchResultItem(
                     id: index,
-                    name: cubeType.name,
-                    imageString: cubeType.imageName,
-                    price: Price(id: "\(index)", amount: index * 1_000, currency: "฿")
+                    name: item.name,
+                    imageString: item.imageName,
+                    price: item.price
                 )
             )
         }
         return items
-    }
-}
-
-private enum CubeType: String, CaseIterable {
-
-    case gray, pink, indigo, honey, gray1, pink1, indigo1, honey1
-
-    var value: String {
-        switch self {
-        case .gray, .gray1: return "gray"
-        case .pink, .pink1: return "pink"
-        case .indigo, .indigo1: return "indigo"
-        case .honey, .honey1: return "honey"
-        }
-    }
-
-    var name: String {
-        "\(value) cube"
-    }
-
-    var imageName: String {
-        "dummy-tshirt/tshirt-cube-\(value)"
     }
 }

--- a/ecommerce-ios/Sources/Collection/CollectionScreen.swift
+++ b/ecommerce-ios/Sources/Collection/CollectionScreen.swift
@@ -48,7 +48,7 @@ struct CollectionScreen: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .accentColor(.mainBlue)
+        .accentColor(.darkBlue)
     }
 }
 

--- a/ecommerce-ios/Sources/Collection/CollectionScreen.swift
+++ b/ecommerce-ios/Sources/Collection/CollectionScreen.swift
@@ -1,0 +1,60 @@
+//
+//  CollectionScreen.swift
+//  ecommerce-ios
+//
+//  Created by Su T. Nguyen on 26/05/2021.
+//
+
+import SwiftUI
+
+struct CollectionScreen: View {
+
+    let viewModel: CollectionViewModel
+
+    @State private var isFilterScreenPresenting: Bool = false
+
+    private let numberOfColumns = 2
+    private let spacing: CGFloat = 17.0
+
+    private var columns: [GridItem] {
+        .init(repeating: GridItem(.flexible()), count: numberOfColumns)
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            CustomNavigationBarLargeTitleView(
+                titleView: {
+                    Text(viewModel.name.capitalized)
+                        .font(.largeTitle.bold())
+                },
+                trailingView: {
+                    Button("Filter(1)") {
+                        isFilterScreenPresenting = true
+                    }
+                    .fullScreenCover(isPresented: $isFilterScreenPresenting) {
+                        NavigationView {
+                            FilterScreen()
+                        }
+                    }
+                }
+            )
+
+            LazyVGrid(columns: columns, spacing: spacing) {
+                ForEach(viewModel.productCellViewModels) { viewModel in
+                    NavigationLink(destination: ProductDetailScreen()) {
+                        ProductCell(viewModel: viewModel)
+                    }
+                }
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .accentColor(.mainBlue)
+    }
+}
+
+struct CollectionScreen_Previews: PreviewProvider {
+
+    static var previews: some View {
+        CollectionScreen(viewModel: CollectionViewModel(id: "1", name: "Cube", products: Product.products))
+    }
+}

--- a/ecommerce-ios/Sources/Collection/CollectionViewModel.swift
+++ b/ecommerce-ios/Sources/Collection/CollectionViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  CollectionViewModel.swift
+//  ecommerce-ios
+//
+//  Created by Su T. Nguyen on 26/05/2021.
+//
+
+import Foundation
+
+struct CollectionViewModel: Identifiable {
+
+    let id: String
+    let name: String
+    let products: [Product]
+
+    var productCellViewModels: [ProductCellViewModel] {
+        Product.products.map { ProductCellViewModel(id: $0.id, product: $0) }
+    }
+}

--- a/ecommerce-ios/Sources/Home/HomeScreen.swift
+++ b/ecommerce-ios/Sources/Home/HomeScreen.swift
@@ -10,37 +10,65 @@ import SwiftUI
 struct HomeScreen: View {
 
     private var tab: Constants.TabBar = .home
+    private var viewModel = HomeViewModel()
+
+    @State private var collectionName: String = ""
+    @State private var gotoSuggestedCollection: Bool = false
+    @State private var gotoCollection: Bool = false
 
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack {
-                    SuggestedView()
-                        .cornerRadius(12.0)
-                        .offset(x: 0.0, y: 20.0)
-                        .padding([.horizontal], 10.0)
+                    NavigationLink(
+                        destination: CollectionScreen(viewModel: viewModel.collectionViewModel),
+                        isActive: $gotoSuggestedCollection
+                    ) {
+                        EmptyView()
+                    }
+                    NavigationLink(
+                        destination: CollectionScreen(viewModel: viewModel.collectionViewModel(for: collectionName)),
+                        isActive: $gotoCollection
+                    ) {
+                        EmptyView()
+                    }
 
-                    CategoryCollectionView(categories: Category.categories)
+                    SuggestedView(product: viewModel.suggestedProduct) {
+                        gotoSuggestedCollection = true
+                    }
+                    .cornerRadius(12.0)
+                    .offset(x: 0.0, y: 20.0)
+                    .padding([.horizontal], 10.0)
 
-                    ProductCollectionView(viewModel: .init())
+                    CategoryCollectionView(categories: Category.categories) { category in
+                        collectionName = category.name
+                        gotoCollection = true
+                    }
+
+                    ProductCollectionView(viewModel: .init()) {
+                        collectionName = $0
+                        gotoCollection = true
+                    }
                 }
             }
             .navigationBarTitle(tab.title)
-            .navigationBarLargeTitle {
-                CustomNavigationBarLargeTitleView(
-                    titleView: {
-                        Text(tab.title)
-                            .font(.largeNavigationBarTitle)
-                            .foregroundColor(.charadeGray)
-                    },
-                    trailingView: {
-                        Button(
-                            action: { print("did tap profile button") },
-                            label: { Image("dummy-other/avatar-icon") }
-                        )
-                    }
-                )
-            }
+
+            #warning("When implementing #64, when push to another screen, it's still shown")
+//            .navigationBarLargeTitle {
+//                CustomNavigationBarLargeTitleView(
+//                    titleView: {
+//                        Text(tab.title)
+//                            .font(.largeNavigationBarTitle)
+//                            .foregroundColor(.charadeGray)
+//                    },
+//                    trailingView: {
+//                        Button(
+//                            action: { print("did tap profile button") },
+//                            label: { Image("dummy-other/avatar-icon") }
+//                        )
+//                    }
+//                )
+//            }
         }
     }
 }

--- a/ecommerce-ios/Sources/Home/HomeViewModel.swift
+++ b/ecommerce-ios/Sources/Home/HomeViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  HomeViewModel.swift
+//  ecommerce-ios
+//
+//  Created by Su T. Nguyen on 26/05/2021.
+//
+
+import Foundation
+
+struct HomeViewModel {
+
+    var suggestedProduct: Product { Product.suggestedProduct }
+
+    var collectionViewModel: CollectionViewModel {
+        .init(id: "1", name: suggestedProduct.name, products: Product.products)
+    }
+
+    func collectionViewModel(for categoryName: String) -> CollectionViewModel {
+        .init(id: "1", name: categoryName, products: Product.products)
+    }
+}

--- a/ecommerce-ios/Sources/Home/View/CategoryView/CategoryCollectionView.swift
+++ b/ecommerce-ios/Sources/Home/View/CategoryView/CategoryCollectionView.swift
@@ -10,12 +10,16 @@ import SwiftUI
 struct CategoryCollectionView: View {
 
     var categories: [Category]
+    var selectedCategory: ((Category) -> Void)?
     
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .top, spacing: 8.0) {
                 ForEach(categories) { category in
                     CategoryView(category: category)
+                        .onTapGesture {
+                            selectedCategory?(category)
+                        }
                         .frame(width: 80.0, height: 88.0)
                 }
             }

--- a/ecommerce-ios/Sources/Home/View/SuggestedView/SuggestedView.swift
+++ b/ecommerce-ios/Sources/Home/View/SuggestedView/SuggestedView.swift
@@ -9,17 +9,16 @@ import SwiftUI
 
 struct SuggestedView: View {
 
-    private let product = Product(
-        id: "product1",
-        name: "Poly Cube 2021",
-        imageName: "",
-        price: Price(id: "price1", amount: 8_000, currency: "฿")
-    )
+    let product: Product
+    var shopAction: (() -> Void)?
 
     var body: some View {
         ZStack {
             backgroundView
             contentView
+        }
+        .onTapGesture {
+            shopAction?()
         }
         .clipped()
     }
@@ -68,14 +67,14 @@ struct SuggestedView: View {
                 Text("\(product.name)")
                     .foregroundColor(.white)
                     .font(.smallTitle)
-                Text("From \(product.price.currency)\(product.price.amount)")
+                Text("From \(product.formattedPrice)")
                     .foregroundColor(.white)
                     .font(.smallDescription)
             }
 
             Spacer()
             Button("SHOP") {
-                print("Did tap shop button")
+                shopAction?()
             }
             .font(.system(size: 15).bold())
             .frame(width: 74.0, height: 30.0)
@@ -90,7 +89,7 @@ struct SuggestedView: View {
 struct SuggestedView_Previews: PreviewProvider {
 
     static var previews: some View {
-        SuggestedView()
+        SuggestedView(product: Product.suggestedProduct)
             .frame(width: UIScreen.main.bounds.width, height: 386.0)
     }
 }

--- a/ecommerce-ios/Sources/Search/SearchScreen.swift
+++ b/ecommerce-ios/Sources/Search/SearchScreen.swift
@@ -14,7 +14,7 @@ struct SearchScreen: View {
     private let numberOfColumns = 2
     private let spacing: CGFloat = 17.0
 
-    private let cellVỉewModels: [SearchItemCellViewModel] = {
+    private let cellViewModels: [SearchItemCellViewModel] = {
         var vms: [SearchItemCellViewModel] = []
         for searchItem in SearchItem.searchItems {
             vms.append(
@@ -30,7 +30,7 @@ struct SearchScreen: View {
     }()
 
     private var searchResultCellViewModels: [SearchItemCellViewModel] {
-        searchKeyword.trimmed.isEmpty ? cellVỉewModels : cellVỉewModels.filter {
+        searchKeyword.trimmed.isEmpty ? cellViewModels : cellViewModels.filter {
             $0.name.lowercased().contains(searchKeyword.lowercased())
         }
     }

--- a/ecommerce-ios/Sources/SearchResult/SearchResultScreen.swift
+++ b/ecommerce-ios/Sources/SearchResult/SearchResultScreen.swift
@@ -16,13 +16,13 @@ struct SearchResultScreen: View {
     private let numberOfColumns = 2
     private let spacing: CGFloat = 17.0
 
-    private let cellVỉewModels: [ProductCellViewModel] = {
+    private let cellViewModels: [ProductCellViewModel] = {
         #warning("implement mock view model for product")
         var vms: [ProductCellViewModel] = []
         for item in SearchResultItem.searchResultItems {
             vms.append(
                 ProductCellViewModel(
-                    id: item.id,
+                    id: "\(item.id)",
                     name: item.name,
                     imageString: item.imageString,
                     price: 1_000,
@@ -59,7 +59,7 @@ struct SearchResultScreen: View {
             )
 
             LazyVGrid(columns: columns, spacing: spacing) {
-                ForEach(cellVỉewModels) { viewModel in
+                ForEach(cellViewModels) { viewModel in
                     NavigationLink(destination: ProductDetailScreen()) {
                         ProductCell(viewModel: viewModel)
                     }

--- a/ecommerce-ios/Views/ProductCell/ProductCell.swift
+++ b/ecommerce-ios/Views/ProductCell/ProductCell.swift
@@ -47,7 +47,7 @@ struct ProductCell_Previews: PreviewProvider {
     static var previews: some View {
         ProductCell(
             viewModel: ProductCellViewModel(
-                id: 1,
+                id: "1",
                 name: "Pink cube",
                 imageString: "dummy-tshirt/tshirt-cube-pink",
                 price: 10_000,

--- a/ecommerce-ios/Views/ProductCell/ProductCellViewModel.swift
+++ b/ecommerce-ios/Views/ProductCell/ProductCellViewModel.swift
@@ -7,13 +7,26 @@
 
 struct ProductCellViewModel: Identifiable {
 
-    var id: Int
-    var name: String
-    var imageString: String
-    var price: Double
-    var currency: String
+    let id: String
+    let name: String
+    let imageString: String
+    let price: Double
+    let currency: String
 
     var formattedPrice: String {
         "\(currency)\(price.formatted(with: .currencyWithNoDecimalDigit))"
+    }
+}
+
+extension ProductCellViewModel {
+
+    init(id: String, product: Product) {
+        self.init(
+            id: id,
+            name: product.name,
+            imageString: product.imageName,
+            price: product.price.amount,
+            currency: product.price.currency
+        )
     }
 }

--- a/ecommerce-ios/Views/ProductCollectionView/ProductCollectionView.swift
+++ b/ecommerce-ios/Views/ProductCollectionView/ProductCollectionView.swift
@@ -11,6 +11,8 @@ struct ProductCollectionView: View {
 
     let viewModel: ProductCollectionViewViewModel
 
+    var goToCollection: ((String) -> Void)?
+
     private let numberOfColumns: Int = 2
     private let spacing: CGFloat = 17.0
 
@@ -24,11 +26,15 @@ struct ProductCollectionView: View {
         return LazyVStack {
             ForEach(sections) { section in
                 VStack {
-                    ProductSectionHeaderView(viewModel: .init(title: section.title))
+                    ProductSectionHeaderView(viewModel: .init(title: section.title)) {
+                        goToCollection?(section.title)
+                    }
 
                     LazyVGrid(columns: columns, spacing: spacing) {
                         ForEach(section.cellViewModels) { cellVM in
-                            ProductCell(viewModel: cellVM)
+                            NavigationLink(destination: ProductDetailScreen()) {
+                                ProductCell(viewModel: cellVM)
+                            }
                         }
                     }
                     .padding(.vertical, 10.0)

--- a/ecommerce-ios/Views/ProductCollectionView/ProductSectionViewModel.swift
+++ b/ecommerce-ios/Views/ProductCollectionView/ProductSectionViewModel.swift
@@ -22,11 +22,8 @@ extension ProductSectionViewModel {
         var cellVMs: [ProductCellViewModel] = []
         for index in 0..<collection.numberOfItems {
              let cellVM = ProductCellViewModel(
-                id: index,
-                name: "Pink cube",
-                imageString: "dummy-tshirt/tshirt-cube-pink",
-                price: 10_000,
-                currency: "฿"
+                id: "\(index)",
+                product: Product.products.first ?? Product.suggestedProduct
             )
             cellVMs.append(cellVM)
         }

--- a/ecommerce-ios/Views/ProductSectionHeader/ProductSectionHeaderView.swift
+++ b/ecommerce-ios/Views/ProductSectionHeader/ProductSectionHeaderView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProductSectionHeaderView: View {
 
     let viewModel: ProductSectionHeaderViewViewModel
+    var selectedShop: (() -> Void)?
 
     var body: some View {
         HStack {
@@ -18,7 +19,7 @@ struct ProductSectionHeaderView: View {
                 .foregroundColor(.charadeGray)
             Spacer()
             Button("Shop all") {
-                print("Did tap shop all button")
+                selectedShop?()
             }
             .font(.system(size: 15.0))
             .foregroundColor(.indigoViolet)


### PR DESCRIPTION
#64
#63
#66

## What happened 👀

At Home, the user can go to Product Collection by 4 ways:
- Tap on `Suggested View`
- Tap on `Shop` button on `Suggested View`
- Tap on `Category Item`
- Tap on `Shop all` button of Product Grouped By
 
## Insight 📝

- Re-create dummy product list
- Create collection screen, and handle navigate to Product detail when tap on product
- Comment out profile button on navigation bar at `Home` because the navigation bar still shows when we push new screen into, so we're currently using a wrong custom for navigation bar.

## Proof Of Work 📹

![2021-05-26 17 41 59](https://user-images.githubusercontent.com/17830319/119647454-7d102700-be4a-11eb-89c5-f85aba1ae3f8.gif)

