### PR TITLE
[85] [UI] As a user, I can see Large widget layout correctly when having 4 items or less

### DIFF
--- a/ecommerce-iosWidget/WidgetView/ItemsGridView.swift
+++ b/ecommerce-iosWidget/WidgetView/ItemsGridView.swift
@@ -23,7 +23,8 @@ struct ItemsGridView: View {
                     .aspectRatio(1.0, contentMode: .fit)
             }
             ForEach(0..<spacingItems(currentItems: items.count)) { _ in
-                Spacer()                    .aspectRatio(1.0, contentMode: .fit)
+                Spacer()
+                    .aspectRatio(1.0, contentMode: .fit)
             }
         }
     }

--- a/ecommerce-iosWidget/WidgetView/ItemsGridView.swift
+++ b/ecommerce-iosWidget/WidgetView/ItemsGridView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct ItemsGridView: View {
 
+    @Environment(\.widgetFamily) var family
+
     var items: [ItemViewModel]
 
     let columns = Array(repeating: GridItem(.flexible()), count: 4)
@@ -20,14 +22,21 @@ struct ItemsGridView: View {
                 ItemView(item: item)
                     .aspectRatio(1.0, contentMode: .fit)
             }
+            ForEach(0..<spacingItems(currentItems: items.count)) { _ in
+                Spacer()                    .aspectRatio(1.0, contentMode: .fit)
+            }
         }
+    }
+
+    private func spacingItems(currentItems: Int) -> Int {
+        return max(family.maxCount - currentItems, 0)
     }
 }
 
 struct ItemsGridView_Previews: PreviewProvider {
 
     static var previews: some View {
-        ItemsGridView(items: ItemViewModel.placeholder)
+        ItemsGridView(items: Array(ItemViewModel.placeholder.prefix(3)))
             .previewContext(WidgetPreviewContext(family: .systemLarge))
     }
 }

--- a/ecommerce-iosWidget/WidgetView/Sizes/LargeWidget/LargeWidgetView.swift
+++ b/ecommerce-iosWidget/WidgetView/Sizes/LargeWidget/LargeWidgetView.swift
@@ -50,7 +50,7 @@ struct LargeWidgetView_Previews: PreviewProvider {
                 product: .placeholderItem,
                 promotionText: "POPULAR"
             ),
-            itemViewModels: ItemViewModel.placeholder
+            itemViewModels: Array(ItemViewModel.placeholder.prefix(4))
         )
         .previewContext(WidgetPreviewContext(family: .systemLarge))
     }

--- a/ecommerce-iosWidget/WidgetView/Sizes/LargeWidget/LargeWidgetView.swift
+++ b/ecommerce-iosWidget/WidgetView/Sizes/LargeWidget/LargeWidgetView.swift
@@ -50,7 +50,7 @@ struct LargeWidgetView_Previews: PreviewProvider {
                 product: .placeholderItem,
                 promotionText: "POPULAR"
             ),
-            itemViewModels: Array(ItemViewModel.placeholder.prefix(4))
+            itemViewModels: Array(ItemViewModel.placeholder.prefix(3))
         )
         .previewContext(WidgetPreviewContext(family: .systemLarge))
     }


### PR DESCRIPTION
resolves https://github.com/nimblehq/nimble-ecommerce-ios/issues/85

## What happened 👀

Add spacing when item does not fill grid.
 
## Insight 📝

When item does not fill grid, view will be messy. Fixed by adding `Spacer` for empty places.
 
## Proof Of Work 📹

<img width="1512" alt="Screen Shot 2021-05-27 at 11 54 26" src="https://user-images.githubusercontent.com/6356137/119768186-6c12f480-bee2-11eb-84ac-eadc4826ea7e.png">
