### PR TITLE
[51] [UI] As a user, I can see the related product section on the Product Detail screen

### DIFF
--- a/ecommerce-ios/Sources/ProductDetail/ProductDetailScreen.swift
+++ b/ecommerce-ios/Sources/ProductDetail/ProductDetailScreen.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ProductDetailScreen: View {
 
+    let relatedProductsVM = CollectionViewModel(id: "1", name: "Related", products: Product.products)
+    @State private var gotoCollection: Bool = false
+
     var body: some View {
         ScrollView {
             Section {
@@ -23,7 +26,10 @@ struct ProductDetailScreen: View {
                 SizeSelectionView(cellViewModels: ProductSizeType.allCases.map(SizeCellViewModel.init))
             }
 
-            #warning("Implement the related products")
+            Section(header: titleText("")) {
+                relatedProducts()
+            }
+
             Spacer(minLength: 20.0)
         }
     }
@@ -35,15 +41,44 @@ struct ProductDetailScreen: View {
                 .padding(.horizontal, 20.0)
                 .padding(.top, 30.0)
                 .padding(.bottom, 20.0)
-            HStack {
-                Text(title.capitalized)
-                    .font(.headlineTitle)
-                    .foregroundColor(.charadeGray)
-                    .padding(.horizontal, 16.0)
-                Spacer()
+            if !title.isEmpty {
+                HStack {
+                    Text(title.capitalized)
+                        .font(.headlineTitle)
+                        .foregroundColor(.charadeGray)
+                        .padding(.horizontal, 16.0)
+                    Spacer()
+                }
+                .padding(.bottom, 8.0)
             }
-            .padding(.bottom, 8.0)
         }
+    }
+
+    private func relatedProducts() -> some View {
+        VStack {
+            NavigationLink(
+                destination: CollectionScreen(viewModel: relatedProductsVM),
+                isActive: $gotoCollection
+            ) {
+                EmptyView()
+            }
+
+            ProductSectionHeaderView(viewModel: .init(title: relatedProductsVM.name)) {
+                gotoCollection = true
+            }
+
+            let columns: [GridItem] = .init(repeating: GridItem(.flexible()), count: 2)
+
+            LazyVGrid(columns: columns, spacing: 17.0) {
+                ForEach(relatedProductsVM.productCellViewModels) { cellVM in
+                    NavigationLink(destination: ProductDetailScreen()) {
+                        ProductCell(viewModel: cellVM)
+                    }
+                }
+            }
+            .padding(.vertical, 10.0)
+        }
+        .padding(.horizontal, 16.0)
     }
 }
 


### PR DESCRIPTION
#51 

## What happened 👀

- The related product section on the Product Detail screen contains:
- Title label on the top. The title has the formatted content: More <product type name>. Ex: "More Cube"
- The "Shop all" button
- A related product collection.

## Insight 📝


## Proof Of Work 📹

![2021-05-31 18 24 21](https://user-images.githubusercontent.com/17830319/120187711-5df50900-c23f-11eb-949e-9547ba7ee6a9.gif)

