### PR TITLE
[79] As a user, I can tap on small widget to show that item on the app

### DIFF
--- a/ecommerce-iosWidget/WidgetView/Sizes/SmallWidgetView.swift
+++ b/ecommerce-iosWidget/WidgetView/Sizes/SmallWidgetView.swift
@@ -36,6 +36,7 @@ struct SmallWidgetView: View {
 
             LogoView()
         }
+        .widgetURL(viewModel.productURL)
     }
 }
 


### PR DESCRIPTION
resolves https://github.com/nimblehq/nimble-ecommerce-ios/issues/79

## What happened 👀

Add deeplink for small widget.
 
## Insight 📝

Small widget can have one deeplink.

## Proof Of Work 📹


https://user-images.githubusercontent.com/6356137/120455802-45136180-c3bf-11eb-985d-3eff34575132.mp4

